### PR TITLE
Hardcoding About Pages

### DIFF
--- a/content/settings/routes.yaml
+++ b/content/settings/routes.yaml
@@ -15,6 +15,14 @@ collections:
     permalink: /splash/
     template: splash
 
+  /en/about/:
+    permalink: /en/about/
+    template: About
+
+  /fr/about/:
+    permalink: /fr/about/
+    template: About-fr
+
   /en/12-days-of-data/:
     permalink: /en/12-days-of-data/
     template: dataDays


### PR DESCRIPTION
The new about pages will be at /en/about & /fr/about. These new routes will just have to be set in the Ghost Admin panel once the changes are live.